### PR TITLE
Fix "No such file" error by restoring working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 
 # Mac
 .DS_Store
+benchmark-runner/scripts/benchmark-results/

--- a/benchmark-runner/scripts/run-benchmark.sh
+++ b/benchmark-runner/scripts/run-benchmark.sh
@@ -206,13 +206,16 @@ trap cleanup EXIT
 build_jars() {
     log "Building project JARs..."
 
-    cd "$PROJECT_ROOT"
-
+    # Temporarily switch context to build the project
+    pushd "$PROJECT_ROOT"
 
     if [[ ! -f "$RUNNER_JAR" ]]; then
         log "Building benchmark-runner module..."
         JAVA_HOME="$JAVA_HOME" mvn package -pl benchmark-runner -am -DskipTests -q
     fi
+
+    # Restore original working directory
+    popd
 
     log "JARs ready"
 }


### PR DESCRIPTION
The `build_jars` function was permanently changing the shell's directory to the project root. This caused relative paths for output files (defined in the scripts dir) to resolve incorrectly later in the script.

Switched to `pushd/popd` to ensure the execution context is restored after the build completes.

By following the documentation at 
https://github.com/franz1981/Netty-VirtualThread-Scheduler/blob/master/benchmark-runner/README.md?plain=1#L25-L37

The script will fail with: `tee: ./benchmark-results/wrk-results.txt: No such file or directory`

```
tee: ./benchmark-results/wrk-results.txt: No such file or directory
[2026-01-19 17:40:37] Cleaning up...
[2026-01-19 17:40:37] Stopping mock server (PID: 1616)
[2026-01-19 17:40:37] Stopping handoff server (PID: 1651)
[2026-01-19 17:40:38] Cleanup complete
```

With the fix, we will have the following logs:
```
[2026-01-19 18:09:48] Load test complete
[2026-01-19 18:09:48] Results saved to: ./benchmark-results/wrk-results.txt
[2026-01-19 18:09:48] Benchmark complete!
[2026-01-19 18:09:48] Results in: ./benchmark-results
[2026-01-19 18:09:48] Cleaning up...
[2026-01-19 18:09:48] Stopping mock server (PID: 1324)
[2026-01-19 18:09:48] Stopping handoff server (PID: 1359)
[2026-01-19 18:09:49] Cleanup complete
```