### PR TITLE
Move the mock server to use epoll which can benefit, on recent kernel…

### DIFF
--- a/benchmark-runner/scripts/run-benchmark.sh
+++ b/benchmark-runner/scripts/run-benchmark.sh
@@ -24,8 +24,8 @@ JAVA_OPTS="${JAVA_OPTS:--Xms1g -Xmx1g}"
 # Mock server configuration
 MOCK_PORT="${MOCK_PORT:-8080}"
 MOCK_THINK_TIME_MS="${MOCK_THINK_TIME_MS:-1}"
-MOCK_THREADS="${MOCK_THREADS:-}"
-MOCK_TASKSET="${MOCK_TASKSET:-4,5,6,7}"  # CPUs for mock server
+MOCK_THREADS="${MOCK_THREADS:-1}"
+MOCK_TASKSET="${MOCK_TASKSET:-4,5}"  # CPUs for mock server
 
 # Handoff server configuration
 SERVER_PORT="${SERVER_PORT:-8081}"


### PR DESCRIPTION
See https://github.com/netty/netty/blob/d65f6ae6153a15ab4c4871ce487bd19160ad473a/transport-native-epoll/src/main/c/netty_epoll_native.c#L334 
```
epoll_pwait2()
       The  epoll_pwait2() system call is equivalent to epoll_pwait() except for the timeout argument.  It takes
       an argument of type timespec to  be  able  to  specify  nanosecond  resolution  timeout.   This  argument
       functions  the  same  as  in  [pselect](https://manpages.ubuntu.com/manpages/noble/man2/pselect.2.html)(2) and [ppoll](https://manpages.ubuntu.com/manpages/noble/man2/ppoll.2.html)(2).  If timeout is NULL, then epoll_pwait2() can block
       indefinitely.
```
thanks to this we can reduce drammatically the number of threads required by the `mock` server 

fyi @AlanBateman

After this change, the mock server is correctly using the mentioned method:
<img width="1908" height="1197" alt="image" src="https://github.com/user-attachments/assets/1836d984-e601-485c-ba1c-17b3ced7f4eb" />


This is to have a much better think time with the server :heart: 


