### PR TITLE
Refactor scheduler discovery and unify JVM argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,134 @@ mvn clean install
 
 - If you need the virtual thread to inherit the scheduler when forking tasks via StructuredTaskScope, pass the group's `vThreadFactory()` to the scope's `withThreadFactory(...)`.
 
+## Classloader requirements for fat JARs and application servers
+
+The JVM loads the custom virtual-thread scheduler via the **system classloader**
+(`ClassLoader.getSystemClassLoader()`). Many frameworks — Spring Boot, OpenLiberty,
+WildFly, and others — use isolated classloaders that hide application JARs from
+the system classloader. If you deploy this library inside such a framework, the
+JVM will fail to find `NettyScheduler` at startup.
+
+The library is split into two modules to handle this:
+
+| Module | Contains | Must be visible to |
+|---|---|---|
+| `netty-virtualthread-bootstrap` | `NettyScheduler` shim + `NettySchedulerSpi` interface (no dependencies) | System classloader |
+| `netty-virtualthread-core` | Real scheduling logic (`NettySchedulerProviderImpl`) | Thread-context classloader (TCCL) |
+
+`NettyScheduler` discovers the real implementation at runtime via `ServiceLoader`
+using the TCCL — the same pattern JDBC uses to discover drivers. As long as the
+bootstrap classes are on the system classpath and the core JAR is visible to the
+TCCL, discovery works regardless of classloader hierarchy.
+
+### Plain classpath (shade plugin, flat classpath)
+
+No special configuration needed. Both modules are on the same classpath.
+
+### Spring Boot fat JAR
+
+Spring Boot packages dependencies under `BOOT-INF/lib/`, invisible to the system
+classloader. Use Multi-Release JAR (MRJAR) entries to place the bootstrap classes
+at the outer level of the fat JAR:
+
+```xml
+<!-- 1. Mark the JAR as Multi-Release -->
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <configuration>
+        <archive>
+            <manifestEntries>
+                <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+        </archive>
+    </configuration>
+</plugin>
+
+<!-- 2. Unpack bootstrap classes into META-INF/versions/27/ -->
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>unpack-bootstrap-scheduler</id>
+            <phase>prepare-package</phase>
+            <goals>
+                <goal>unpack</goal>
+            </goals>
+            <configuration>
+                <artifactItems>
+                    <artifactItem>
+                        <groupId>io.netty.loom</groupId>
+                        <artifactId>netty-virtualthread-bootstrap</artifactId>
+                        <version>${netty-loom.version}</version>
+                        <type>jar</type>
+                        <includes>io/netty/loom/spi/**</includes>
+                        <outputDirectory>${project.build.outputDirectory}/META-INF/versions/27</outputDirectory>
+                    </artifactItem>
+                </artifactItems>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+
+<!-- 3. Exclude bootstrap from BOOT-INF/lib/ to avoid duplicate class definitions -->
+<plugin>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-maven-plugin</artifactId>
+    <configuration>
+        <excludes>
+            <exclude>
+                <groupId>io.netty.loom</groupId>
+                <artifactId>netty-virtualthread-bootstrap</artifactId>
+            </exclude>
+        </excludes>
+    </configuration>
+</plugin>
+```
+
+The resulting JAR layout:
+
+```
+app.jar
+├── META-INF/MANIFEST.MF          (Multi-Release: true)
+├── META-INF/versions/27/
+│   └── io/netty/loom/spi/
+│       ├── NettyScheduler.class
+│       └── NettySchedulerSpi.class
+└── BOOT-INF/lib/
+    └── netty-virtualthread-core-*.jar
+```
+
+On Java 27+, the system classloader sees the bootstrap classes via MRJAR. The
+core implementation is discovered via ServiceLoader through Spring Boot's
+`LaunchedClassLoader` (which is set as the TCCL).
+
+Credit: [dreamlike-ocean](https://github.com/dreamlike-ocean) for identifying and
+fixing this issue.
+
+### OpenLiberty, WildFly, and other application servers
+
+The same principle applies: the bootstrap JAR must be visible to the system
+classloader. The mechanism varies by server:
+
+- **OpenLiberty**: configure the bootstrap JAR as a
+  [shared library](https://openliberty.io/docs/latest/class-loader-library-config.html)
+  at server scope, or add it via `jvm.options`:
+  ```
+  -Xbootclasspath/a:/path/to/netty-virtualthread-bootstrap.jar
+  ```
+- **WildFly**: register the bootstrap JAR as a
+  [global module](https://docs.wildfly.org/latest/Developer_Guide.html#global-modules),
+  or add it to `JBOSS_MODULEPATH`.
+- **Generic**: place the bootstrap JAR on the JVM's `-classpath` or
+  `-Xbootclasspath/a:` separately from the application archive. The core JAR
+  stays inside the application's deployment unit.
+
+In all cases, `netty-virtualthread-core` should be packaged inside the
+application (WAR/EAR) as a normal dependency — the TCCL will be the application
+classloader at the point when `NettyScheduler` discovers it.
+
 ## JFR events
 Netty Loom publishes custom Java Flight Recorder events (disabled by default) for scheduler activity:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This allows code that must block (for example, blocking I/O or synchronous libra
 - Call `group.vThreadFactory()` to obtain a `ThreadFactory` that creates virtual threads tied to an `EventLoopScheduler` of the group. When those virtual threads block, the scheduler parks them and resumes them later using the carrier thread.
 - Virtual threads created via the group's `vThreadFactory()` will attempt to inherit the scheduler and run with low-overhead handoffs back to the event loop when continuing work.
 - Virtual threads created with `Thread.ofVirtual().factory()` (the JVM default factory) do NOT automatically inherit the group's scheduler.
-- The library requires a custom global virtual thread scheduler implementation to be installed: set `-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler` (or use the convenience helpers in the code/tests that set up the scheduler).
+- The library requires a custom global virtual thread scheduler implementation to be installed: set `-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler` (or use the convenience helpers in the code/tests that set up the scheduler).
 - Blocking I/O support that relies on per-carrier pollers currently depends on the JVM poller mode (the code checks `jdk.pollerMode==3`). See notes below.
 
 ## When to use this
@@ -92,7 +92,7 @@ mvn clean install
 
 ## Integration tips and runtime flags
 - Install the Netty scheduler as the JVM virtual-thread scheduler with:
-  `-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler`
+  `-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler`
 
 - Some blocking I/O integrations rely on per-carrier pollers. The code checks `jdk.pollerMode` and expects value `3` for per-carrier pollers. This can be controlled via JVM flags or defaults depending on your JVM version.
 
@@ -131,7 +131,7 @@ java -jar target/benchmarks.jar
 ## Prerequisites
 - Maven 3.6+
 - To use the `VirtualMultithreadIoEventLoopGroup` set the JVM property to install the Netty scheduler:
-  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler
+  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler
 
 ## References
 - Project Loom (OpenJDK): https://openjdk.org/projects/loom/

--- a/benchmark-runner/README.md
+++ b/benchmark-runner/README.md
@@ -319,7 +319,7 @@ java \
   -XX:+UnlockExperimentalVMOptions \
   -XX:-DoJVMTIVirtualThreadTransitions \
   -Djdk.trackAllThreads=false \
-  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler \
+  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler \
   -Djdk.pollerMode=3 \
   -cp benchmark-runner/target/benchmark-runner.jar \
   io.netty.loom.benchmark.runner.HandoffHttpServer \

--- a/benchmark-runner/scripts/run-benchmark.sh
+++ b/benchmark-runner/scripts/run-benchmark.sh
@@ -386,7 +386,7 @@ start_handoff_server() {
     local poller_mode="$SERVER_POLLER_MODE"
     case "$SERVER_MODE" in
         NETTY_SCHEDULER)
-            jvm_args="$jvm_args -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler"
+            jvm_args="$jvm_args -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler"
             # Default pollerMode to 3 for custom scheduler if not explicitly set
             poller_mode="${poller_mode:-3}"
             ;;

--- a/benchmarks/src/main/java/io/netty/loom/benchmark/NettySchedulerBenchmark.java
+++ b/benchmarks/src/main/java/io/netty/loom/benchmark/NettySchedulerBenchmark.java
@@ -60,7 +60,7 @@ public class NettySchedulerBenchmark {
 	@Benchmark
 	@Fork(value = 2, jvmArgs = {"--add-opens=java.base/java.lang=ALL-UNNAMED", "-XX:+UnlockExperimentalVMOptions",
 			"-XX:-DoJVMTIVirtualThreadTransitions", "-Djdk.trackAllThreads=false",
-			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler", "-Djdk.pollerMode=3"})
+			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler", "-Djdk.pollerMode=3"})
 	public void scheduleToFjFromNetty() {
 		CountDownLatch countDown = new CountDownLatch(tasks);
 		vtFactory.newThread(() -> {
@@ -95,7 +95,7 @@ public class NettySchedulerBenchmark {
 	@Benchmark
 	@Fork(value = 2, jvmArgs = {"--add-opens=java.base/java.lang=ALL-UNNAMED", "-XX:+UnlockExperimentalVMOptions",
 			"-XX:-DoJVMTIVirtualThreadTransitions", "-Djdk.trackAllThreads=false",
-			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler", "-Djdk.pollerMode=3"})
+			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler", "-Djdk.pollerMode=3"})
 	public void scheduleToFjFromFjWithCustomScheduler() {
 		CountDownLatch countDown = new CountDownLatch(tasks);
 		Thread.startVirtualThread(() -> {
@@ -113,7 +113,7 @@ public class NettySchedulerBenchmark {
 	@Benchmark
 	@Fork(value = 2, jvmArgs = {"--add-opens=java.base/java.lang=ALL-UNNAMED", "-XX:+UnlockExperimentalVMOptions",
 			"-XX:-DoJVMTIVirtualThreadTransitions", "-Djdk.trackAllThreads=false",
-			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler", "-Djdk.pollerMode=3"})
+			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler", "-Djdk.pollerMode=3"})
 	public void scheduleToNettyFromNetty() {
 		CountDownLatch countDown = new CountDownLatch(tasks);
 		vtFactory.newThread(() -> {

--- a/benchmarks/src/main/java/io/netty/loom/benchmark/SchedulerHandoffBenchmark.java
+++ b/benchmarks/src/main/java/io/netty/loom/benchmark/SchedulerHandoffBenchmark.java
@@ -141,7 +141,7 @@ public class SchedulerHandoffBenchmark {
 	@Benchmark
 	@Fork(value = 2, jvmArgs = {"--add-opens=java.base/java.lang=ALL-UNNAMED", "-XX:+UnlockExperimentalVMOptions",
 			"-XX:-DoJVMTIVirtualThreadTransitions", "-Djdk.trackAllThreads=false",
-			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler", "-Djdk.pollerMode=3",
+			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler", "-Djdk.pollerMode=3",
 			"-DelThreads=1"})
 	public void customScheduler(Blackhole bh) throws InterruptedException {
 		doRequest(bh);
@@ -150,7 +150,7 @@ public class SchedulerHandoffBenchmark {
 	@Benchmark
 	@Fork(value = 2, jvmArgs = {"--add-opens=java.base/java.lang=ALL-UNNAMED", "-XX:+UnlockExperimentalVMOptions",
 			"-XX:-DoJVMTIVirtualThreadTransitions", "-Djdk.trackAllThreads=false",
-			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler", "-Djdk.pollerMode=3",
+			"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler", "-Djdk.pollerMode=3",
 			"-DelThreads=2"})
 	public void customSchedulerTwoEL(Blackhole bh) throws InterruptedException {
 		doRequest(bh);

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.netty.loom</groupId>
+        <artifactId>netty-virtualthread-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netty-virtualthread-bootstrap</artifactId>
+
+    <!-- No dependencies: this module must stay JDK-only so it can sit on the
+         system classpath without pulling in Netty or any other library. -->
+
+</project>

--- a/bootstrap/src/main/java/io/netty/loom/spi/NettyScheduler.java
+++ b/bootstrap/src/main/java/io/netty/loom/spi/NettyScheduler.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Netty VirtualThread Scheduler Project
+ *
+ * The Netty VirtualThread Scheduler Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package io.netty.loom.spi;
+
+import java.util.ServiceLoader;
+
+/**
+ * Thin bootstrap scheduler loaded by the JDK via
+ * {@code -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler}.
+ *
+ * <p>
+ * This class must live on the <em>system</em> class path (or boot class path)
+ * because {@code VirtualThread.loadCustomScheduler()} uses
+ * {@code ClassLoader.getSystemClassLoader()}. It has <b>no</b> Netty
+ * dependencies — all real scheduling logic is discovered at runtime via
+ * {@link ServiceLoader} from the thread-context class loader, exactly like JDBC
+ * discovers drivers.
+ */
+public class NettyScheduler implements Thread.VirtualThreadScheduler {
+
+	static volatile NettyScheduler INSTANCE;
+
+	private final Thread.VirtualThreadScheduler jdkBuiltinScheduler;
+	private final NettySchedulerSpi provider;
+	private final boolean perCarrierPollers;
+
+	public NettyScheduler(Thread.VirtualThreadScheduler jdkBuiltinScheduler) {
+		this.jdkBuiltinScheduler = jdkBuiltinScheduler;
+		this.perCarrierPollers = Integer.getInteger("jdk.pollerMode", -1) == 3;
+
+		ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+		if (tccl == null) {
+			tccl = ClassLoader.getSystemClassLoader();
+		}
+		ServiceLoader<NettySchedulerSpi> loader = ServiceLoader.load(NettySchedulerSpi.class, tccl);
+		NettySchedulerSpi found = loader.findFirst().orElse(null);
+		if (found != null) {
+			found.init(jdkBuiltinScheduler);
+		}
+		this.provider = found;
+		INSTANCE = this;
+	}
+
+	public static NettyScheduler instance() {
+		return ensureInstalled();
+	}
+
+	public Thread.VirtualThreadScheduler jdkBuiltinScheduler() {
+		return jdkBuiltinScheduler;
+	}
+
+	public boolean expectsPerCarrierPollers() {
+		return perCarrierPollers;
+	}
+
+	@Override
+	public void onStart(Thread.VirtualThreadTask task) {
+		if (provider != null) {
+			provider.onStart(task);
+		} else {
+			jdkBuiltinScheduler.onStart(task);
+		}
+	}
+
+	@Override
+	public void onContinue(Thread.VirtualThreadTask task) {
+		if (provider != null) {
+			provider.onContinue(task);
+		} else {
+			jdkBuiltinScheduler.onContinue(task);
+		}
+	}
+
+	private static NettyScheduler ensureInstalled() {
+		var instance = INSTANCE;
+		if (instance != null) {
+			return instance;
+		}
+		Thread.ofVirtual().unstarted(new Runnable() {
+			@Override
+			public void run() {
+			}
+		});
+		return INSTANCE;
+	}
+
+	public static boolean perCarrierPollers() {
+		return ensureInstalled().perCarrierPollers;
+	}
+
+	public static boolean isAvailable() {
+		var instance = ensureInstalled();
+		return instance != null && instance.provider != null;
+	}
+}

--- a/bootstrap/src/main/java/io/netty/loom/spi/NettyScheduler.java
+++ b/bootstrap/src/main/java/io/netty/loom/spi/NettyScheduler.java
@@ -104,4 +104,8 @@ public class NettyScheduler implements Thread.VirtualThreadScheduler {
 		var instance = ensureInstalled();
 		return instance != null && instance.provider != null;
 	}
+
+	public static boolean isInstalled() {
+		return ensureInstalled() != null;
+	}
 }

--- a/bootstrap/src/main/java/io/netty/loom/spi/NettySchedulerSpi.java
+++ b/bootstrap/src/main/java/io/netty/loom/spi/NettySchedulerSpi.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Netty VirtualThread Scheduler Project
+ *
+ * The Netty VirtualThread Scheduler Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package io.netty.loom.spi;
+
+/**
+ * SPI for plugging a virtual-thread scheduling strategy into
+ * {@link NettyScheduler}.
+ *
+ * <p>
+ * Implementations are discovered via {@link java.util.ServiceLoader} using the
+ * thread-context class loader, following the same pattern as JDBC drivers. This
+ * allows the implementation to live inside a Spring Boot fat JAR (or any
+ * non-standard class-loader hierarchy) while {@link NettyScheduler} itself
+ * remains on the system class path.
+ */
+public interface NettySchedulerSpi {
+
+	/**
+	 * Called once, immediately after discovery, to hand the provider the JDK's
+	 * built-in scheduler so it can fall back to it for unrecognised tasks.
+	 */
+	void init(Thread.VirtualThreadScheduler jdkBuiltinScheduler);
+
+	/**
+	 * @see Thread.VirtualThreadScheduler#onStart(Thread.VirtualThreadTask)
+	 */
+	void onStart(Thread.VirtualThreadTask task);
+
+	/**
+	 * @see Thread.VirtualThreadScheduler#onContinue(Thread.VirtualThreadTask)
+	 */
+	void onContinue(Thread.VirtualThreadTask task);
+
+	/**
+	 * Whether this provider expects the JVM to run with per-carrier pollers
+	 * ({@code jdk.pollerMode=3}).
+	 */
+	default boolean expectsPerCarrierPollers() {
+		return false;
+	}
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty.loom</groupId>
+            <artifactId>netty-virtualthread-bootstrap</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>

--- a/core/src/main/java/io/netty/loom/FifoEventLoopScheduler.java
+++ b/core/src/main/java/io/netty/loom/FifoEventLoopScheduler.java
@@ -23,6 +23,7 @@ import io.netty.channel.IoEventLoopGroup;
 import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.ManualIoEventLoop;
 import io.netty.loom.jfr.VirtualThreadTaskSubmitEvent;
+import io.netty.loom.spi.NettyScheduler;
 import io.netty.util.concurrent.FastThreadLocalThread;
 
 final class FifoEventLoopScheduler implements EventLoopScheduler {
@@ -73,7 +74,7 @@ final class FifoEventLoopScheduler implements EventLoopScheduler {
 		// enabling
 		// work-stealing to change it for both
 		var unstartedBuilder = Thread.ofVirtual();
-		NettyScheduler scheduler = NettyScheduler.INSTANCE;
+		NettyScheduler scheduler = NettyScheduler.instance();
 		return runnable -> {
 			var schedulingContext = new SchedulingContext(sharedRef);
 			var vTask = scheduler.newThread(unstartedBuilder, null,

--- a/core/src/main/java/io/netty/loom/NettySchedulerProviderImpl.java
+++ b/core/src/main/java/io/netty/loom/NettySchedulerProviderImpl.java
@@ -14,8 +14,11 @@
  */
 package io.netty.loom;
 
+import io.netty.loom.spi.NettySchedulerSpi;
+
 /**
- * Global Netty scheduler proxy for virtual threads.
+ * Default {@link NettySchedulerSpi} implementation that integrates
+ * virtual-thread scheduling with Netty event loops.
  *
  * <p>
  * Inheritance rule (exact): a newly started virtual thread inherits the
@@ -33,48 +36,24 @@ package io.netty.loom;
  * poller-created virtual threads (recognized by the {@code "-Read-Poller"} name
  * suffix). If either condition above is not met (or the thread kind is
  * unrecognized) the virtual thread falls back to the default JDK scheduler.
- *
- * <p>
- * This class is a proxy/dispatcher and does not implement a standalone
- * scheduling policy. See {@link EventLoopScheduler} for details about scheduler
- * attachment and execution.
  */
+public class NettySchedulerProviderImpl implements NettySchedulerSpi {
 
-public class NettyScheduler implements Thread.VirtualThreadScheduler {
-
-	static volatile NettyScheduler INSTANCE;
-
-	private final Thread.VirtualThreadScheduler jdkBuildinScheduler;
-
+	private Thread.VirtualThreadScheduler jdkBuiltinScheduler;
 	private final boolean perCarrierPollers;
 
-	private static NettyScheduler ensureInstalled() {
-		var instance = INSTANCE;
-		if (instance != null) {
-			return instance;
-		}
-		Thread.ofVirtual().unstarted(new Runnable() {
-			@Override
-			public void run() {
-
-			}
-		});
-		// we expect VirtualThread clinit to have loaded it by now
-		return INSTANCE;
+	public NettySchedulerProviderImpl() {
+		this.perCarrierPollers = Integer.getInteger("jdk.pollerMode", -1) == 3;
 	}
 
-	public NettyScheduler(Thread.VirtualThreadScheduler jdkBuildinScheduler) {
-		this.jdkBuildinScheduler = jdkBuildinScheduler;
-		perCarrierPollers = Integer.getInteger("jdk.pollerMode", -1) == 3;
-		INSTANCE = this;
+	@Override
+	public void init(Thread.VirtualThreadScheduler jdkBuiltinScheduler) {
+		this.jdkBuiltinScheduler = jdkBuiltinScheduler;
 	}
 
+	@Override
 	public boolean expectsPerCarrierPollers() {
 		return perCarrierPollers;
-	}
-
-	Thread.VirtualThreadScheduler jdkBuildinScheduler() {
-		return jdkBuildinScheduler;
 	}
 
 	@Override
@@ -84,21 +63,11 @@ public class NettyScheduler implements Thread.VirtualThreadScheduler {
 			if (eventLoop != null && eventLoop.execute(virtualThreadTask)) {
 				return;
 			}
-			// the v thread has been rejected by its assigned scheduler or its scheduler is
-			// gone
 			virtualThreadTask.attach(null);
 		} else {
 			if (perCarrierPollers) {
-				// Read-Poller threads should always inherit the event loop scheduler from the
-				// caller thread
 				if (Thread.currentThread().isVirtual()) {
-					// TODO
-					// https://github.com/openjdk/loom/blob/12ddf39bb59252a8274d8b937bd075b2a6dbc3f8/src/java.base/share/classes/java/lang/VirtualThread.java#L270C18-L270C33
-					// in theory should be easy to provide a VirtualThreadTask::current method to
-					// avoid the ScopedValue lookup
 					var schedulerRef = EventLoopScheduler.currentThreadSchedulerContext().scheduler();
-					// See
-					// https://github.com/openjdk/loom/blob/12ddf39bb59252a8274d8b937bd075b2a6dbc3f8/src/java.base/share/classes/sun/nio/ch/Poller.java#L723C48-L723C59
 					if (schedulerRef != null) {
 						var scheduler = schedulerRef.get();
 						if (scheduler != null && virtualThreadTask.thread().getName().endsWith("-Read-Poller")) {
@@ -113,7 +82,7 @@ public class NettyScheduler implements Thread.VirtualThreadScheduler {
 				}
 			}
 		}
-		jdkBuildinScheduler.onStart(virtualThreadTask);
+		jdkBuiltinScheduler.onStart(virtualThreadTask);
 	}
 
 	@Override
@@ -123,18 +92,8 @@ public class NettyScheduler implements Thread.VirtualThreadScheduler {
 			if (eventLoop != null && eventLoop.execute(virtualThreadTask)) {
 				return;
 			}
-			// the v thread has been rejected by its assigned scheduler or its scheduler is
-			// gone
 			virtualThreadTask.attach(null);
 		}
-		jdkBuildinScheduler.onContinue(virtualThreadTask);
-	}
-
-	public static boolean perCarrierPollers() {
-		return ensureInstalled().perCarrierPollers;
-	}
-
-	public static boolean isAvailable() {
-		return ensureInstalled() != null;
+		jdkBuiltinScheduler.onContinue(virtualThreadTask);
 	}
 }

--- a/core/src/main/java/io/netty/loom/VirtualMultithreadIoEventLoopGroup.java
+++ b/core/src/main/java/io/netty/loom/VirtualMultithreadIoEventLoopGroup.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import io.netty.channel.IoEventLoop;
 import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.loom.spi.NettyScheduler;
 
 public class VirtualMultithreadIoEventLoopGroup extends MultiThreadIoEventLoopGroup {
 
@@ -47,7 +48,7 @@ public class VirtualMultithreadIoEventLoopGroup extends MultiThreadIoEventLoopGr
 	private static void validateNettyAvailability() {
 		if (!NettyScheduler.isAvailable()) {
 			throw new IllegalStateException(
-					"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler is required to use VirtualMultithreadIoEventLoopGroup");
+					"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler is required to use VirtualMultithreadIoEventLoopGroup");
 		}
 	}
 

--- a/core/src/main/java/io/netty/loom/VirtualMultithreadIoEventLoopGroup.java
+++ b/core/src/main/java/io/netty/loom/VirtualMultithreadIoEventLoopGroup.java
@@ -47,8 +47,14 @@ public class VirtualMultithreadIoEventLoopGroup extends MultiThreadIoEventLoopGr
 
 	private static void validateNettyAvailability() {
 		if (!NettyScheduler.isAvailable()) {
+			if (!NettyScheduler.isInstalled()) {
+				throw new IllegalStateException(
+						"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler is required to use VirtualMultithreadIoEventLoopGroup");
+			}
 			throw new IllegalStateException(
-					"-Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler is required to use VirtualMultithreadIoEventLoopGroup");
+					"NettyScheduler bootstrap is installed but no NettySchedulerSpi provider was found. "
+							+ "Ensure the core module JAR is visible to the thread-context class loader "
+							+ "and META-INF/services/io.netty.loom.spi.NettySchedulerSpi is present.");
 		}
 	}
 

--- a/core/src/main/resources/META-INF/services/io.netty.loom.spi.NettySchedulerSpi
+++ b/core/src/main/resources/META-INF/services/io.netty.loom.spi.NettySchedulerSpi
@@ -1,0 +1,1 @@
+io.netty.loom.NettySchedulerProviderImpl

--- a/core/src/test/java/io/netty/loom/ClassLoaderIsolationTest.java
+++ b/core/src/test/java/io/netty/loom/ClassLoaderIsolationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 The Netty VirtualThread Scheduler Project
+ *
+ * The Netty VirtualThread Scheduler Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package io.netty.loom;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ServiceLoader;
+
+import io.netty.loom.spi.NettySchedulerSpi;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Reproduces the Spring Boot fat-JAR class-loader isolation problem and proves
+ * that {@link ServiceLoader}-based discovery (the SPI fix) works around it.
+ *
+ * <p>
+ * Spring Boot packages application classes under {@code BOOT-INF/classes/} and
+ * loads them via {@code LaunchedClassLoader}. The JDK's
+ * {@code VirtualThread.loadCustomScheduler()} uses
+ * {@code ClassLoader.getSystemClassLoader()} which cannot see those classes.
+ * <p>
+ * This test simulates the same isolation by creating a child-first
+ * {@link URLClassLoader} whose parent <em>blocks</em> {@code io.netty.loom.*}
+ * classes, mimicking the system class loader's blindness in a fat-JAR
+ * deployment.
+ */
+public class ClassLoaderIsolationTest {
+
+	/**
+	 * A class loader that delegates everything to its parent <em>except</em> core
+	 * implementation classes in {@code io.netty.loom.*}. Bootstrap classes in
+	 * {@code io.netty.loom.spi.*} are still visible — they live on the system class
+	 * path. This models the real Spring Boot deployment: the bootstrap JAR is on
+	 * {@code -Xbootclasspath/a:} while implementation classes are inside the fat
+	 * JAR.
+	 */
+	private static final class BlockingParentClassLoader extends ClassLoader {
+
+		BlockingParentClassLoader(ClassLoader parent) {
+			super(parent);
+		}
+
+		@Override
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			if (name.startsWith("io.netty.loom.") && !name.startsWith("io.netty.loom.spi.")) {
+				throw new ClassNotFoundException("Simulated fat-JAR isolation: " + name);
+			}
+			return super.loadClass(name, resolve);
+		}
+	}
+
+	/**
+	 * Reproduces the bug: {@code Class.forName} with a restricted parent class
+	 * loader cannot find the SPI implementation — exactly what happens in Spring
+	 * Boot when the system class loader is used.
+	 */
+	@Test
+	public void classForNameFailsWithRestrictedClassLoader() {
+		ClassLoader blocked = new BlockingParentClassLoader(getClass().getClassLoader());
+		assertThrows(ClassNotFoundException.class,
+				() -> Class.forName("io.netty.loom.NettySchedulerProviderImpl", true, blocked));
+	}
+
+	/**
+	 * Proves the fix: {@code ServiceLoader} with a child-first class loader
+	 * (analogous to Spring Boot's {@code LaunchedClassLoader}) discovers the SPI
+	 * implementation even though the parent class loader blocks it.
+	 */
+	@Test
+	public void serviceLoaderFindsProviderThroughChildFirstClassLoader() {
+		ClassLoader blocked = new BlockingParentClassLoader(getClass().getClassLoader());
+
+		URL[] urls = getClasspathUrls();
+		URLClassLoader childFirst = new ChildFirstClassLoader(urls, blocked);
+
+		ServiceLoader<NettySchedulerSpi> loader = ServiceLoader.load(NettySchedulerSpi.class, childFirst);
+		var provider = loader.findFirst();
+		assertTrue(provider.isPresent(), "ServiceLoader should discover NettySchedulerProviderImpl via child CL");
+	}
+
+	private URL[] getClasspathUrls() {
+		String classpath = System.getProperty("java.class.path");
+		String[] entries = classpath.split(System.getProperty("path.separator"));
+		URL[] urls = new URL[entries.length];
+		for (int i = 0; i < entries.length; i++) {
+			try {
+				urls[i] = new java.io.File(entries[i]).toURI().toURL();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return urls;
+	}
+
+	/**
+	 * A child-first (parent-last) class loader that mimics Spring Boot's
+	 * {@code LaunchedClassLoader}: it tries to load classes from its own URLs
+	 * before delegating to the parent.
+	 */
+	private static final class ChildFirstClassLoader extends URLClassLoader {
+
+		ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+			super(urls, parent);
+		}
+
+		@Override
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			synchronized (getClassLoadingLock(name)) {
+				Class<?> c = findLoadedClass(name);
+				if (c != null) {
+					return c;
+				}
+				if (name.startsWith("io.netty.loom.") && !name.startsWith("io.netty.loom.spi.")) {
+					try {
+						c = findClass(name);
+						if (resolve) {
+							resolveClass(c);
+						}
+						return c;
+					} catch (ClassNotFoundException _) {
+					}
+				}
+				return super.loadClass(name, resolve);
+			}
+		}
+	}
+}

--- a/core/src/test/java/io/netty/loom/ClassLoaderIsolationTest.java
+++ b/core/src/test/java/io/netty/loom/ClassLoaderIsolationTest.java
@@ -81,15 +81,15 @@ public class ClassLoaderIsolationTest {
 	 * implementation even though the parent class loader blocks it.
 	 */
 	@Test
-	public void serviceLoaderFindsProviderThroughChildFirstClassLoader() {
+	public void serviceLoaderFindsProviderThroughChildFirstClassLoader() throws Exception {
 		ClassLoader blocked = new BlockingParentClassLoader(getClass().getClassLoader());
 
 		URL[] urls = getClasspathUrls();
-		URLClassLoader childFirst = new ChildFirstClassLoader(urls, blocked);
-
-		ServiceLoader<NettySchedulerSpi> loader = ServiceLoader.load(NettySchedulerSpi.class, childFirst);
-		var provider = loader.findFirst();
-		assertTrue(provider.isPresent(), "ServiceLoader should discover NettySchedulerProviderImpl via child CL");
+		try (URLClassLoader childFirst = new ChildFirstClassLoader(urls, blocked)) {
+			ServiceLoader<NettySchedulerSpi> loader = ServiceLoader.load(NettySchedulerSpi.class, childFirst);
+			var provider = loader.findFirst();
+			assertTrue(provider.isPresent(), "ServiceLoader should discover NettySchedulerProviderImpl via child CL");
+		}
 	}
 
 	private URL[] getClasspathUrls() {

--- a/core/src/test/java/io/netty/loom/NettySchedulerClassInitTest.java
+++ b/core/src/test/java/io/netty/loom/NettySchedulerClassInitTest.java
@@ -14,6 +14,7 @@
  */
 package io.netty.loom;
 
+import io.netty.loom.spi.NettyScheduler;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/core/src/test/java/io/netty/loom/VirtualMultithreadIoEventLoopGroupTest.java
+++ b/core/src/test/java/io/netty/loom/VirtualMultithreadIoEventLoopGroupTest.java
@@ -38,6 +38,7 @@ import io.netty.channel.*;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.epoll.EpollIoHandler;
+import io.netty.loom.spi.NettyScheduler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 
 import io.netty.channel.uring.IoUring;

--- a/example-echo/README.md
+++ b/example-echo/README.md
@@ -31,7 +31,7 @@ The shade plugin in `example-echo/pom.xml` creates an executable jar in
 
 ```bash
 "$JAVA_HOME/bin/java" --enable-preview \
-  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler \
+  -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler \
   -jar example-echo/target/example-echo-1.0-SNAPSHOT.jar &
 
 # note the PID in $!

--- a/example-echo/pom.xml
+++ b/example-echo/pom.xml
@@ -40,7 +40,7 @@
                     <systemProperties>
                         <systemProperty>
                             <key>jdk.virtualThreadScheduler.implClass</key>
-                            <value>io.netty.loom.NettyScheduler</value>
+                            <value>io.netty.loom.spi.NettyScheduler</value>
                         </systemProperty>
                     </systemProperties>
                     <cleanupDaemonThreads>false</cleanupDaemonThreads>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>bootstrap</module>
         <module>core</module>
         <module>benchmarks</module>
         <module>benchmark-runner</module>
@@ -120,7 +121,7 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
-                                <argLine>--enable-preview -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler -Djdk.traceVirtualThreadLocals=false --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                                <argLine>--enable-preview -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler -Djdk.traceVirtualThreadLocals=false --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             </configuration>
                         </execution>
                         <execution>
@@ -130,7 +131,7 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
-                                <argLine>--enable-preview -Djdk.virtualThreadScheduler.implClass=io.netty.loom.NettyScheduler -Djdk.traceVirtualThreadLocals=false --add-opens=java.base/java.lang=ALL-UNNAMED -Djdk.pollerMode=3</argLine>
+                                <argLine>--enable-preview -Djdk.virtualThreadScheduler.implClass=io.netty.loom.spi.NettyScheduler -Djdk.traceVirtualThreadLocals=false --add-opens=java.base/java.lang=ALL-UNNAMED -Djdk.pollerMode=3</argLine>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
This pull request introduces a new modular bootstrap layer for the Netty VirtualThread Scheduler, separating the system-classpath scheduler entrypoint from the actual Netty logic. It standardizes the JVM property for enabling the custom scheduler, updates documentation and usage throughout the project